### PR TITLE
h1 Tag Fix

### DIFF
--- a/views/cust/confirmRSVN.handlebars
+++ b/views/cust/confirmRSVN.handlebars
@@ -1,5 +1,5 @@
 <h1>Reservation Confirmation</h1>
 
-<p>Hey your reservation has {{transaction}}.</p> 
-<p class="lead">Your reservation code is {{ReservationNumber}}</p>
+<p>Hey your reservation has {{transaction}}. Your reservation code is:</p> 
+<p class="font-weight-bold lead">{{ReservationNumber}}</p>
 <p>Thank you for choosing us!</p>

--- a/views/cust/confirmRSVN.handlebars
+++ b/views/cust/confirmRSVN.handlebars
@@ -1,3 +1,5 @@
+<h1>Reservation Confirmation</h1>
+
 <p>Hey your reservation has {{transaction}}.</p> 
 <p class="lead">Your reservation code is {{ReservationNumber}}</p>
 <p>Thank you for choosing us!</p>

--- a/views/cust/editRSVN.handlebars
+++ b/views/cust/editRSVN.handlebars
@@ -1,3 +1,5 @@
+<h1>Edit Your Reservation</h1>
+
 <form action="/reservation/confirmation?_method=PUT" method="POST" class="edit-RSVN-form" id="edit-RSVN-form">
 <div class="form-group row">
   <label for="custNumPeople" class="col-sm-2 col-form-label">Number of People</label>

--- a/views/cust/errorRSVN.handlebars
+++ b/views/cust/errorRSVN.handlebars
@@ -1,1 +1,3 @@
+<h1>Something goes wrong:</h1>
+
 <p class="lead">{{errormessage}}</p>

--- a/views/cust/findRSVN.handlebars
+++ b/views/cust/findRSVN.handlebars
@@ -1,3 +1,5 @@
+<h1>Find Your Reservation</h1>
+
 <form method="POST" action="/reservation/results">
 <div class="form-group row">
   <label for="editReservationNum" class="col-sm-2 col-form-label">Reservation Code</label>

--- a/views/cust/newRSVN.handlebars
+++ b/views/cust/newRSVN.handlebars
@@ -1,3 +1,5 @@
+<h1>Make New Reservation</h1>
+
 <form action="/reservation/confirmation" method="POST" class="new-RSVN-form" id="new-RSVN-form">
 <fieldset class="form-group">
   <legend>Contact Information</legend>

--- a/views/cust/searchRestaurant.handlebars
+++ b/views/cust/searchRestaurant.handlebars
@@ -1,4 +1,4 @@
-<h1>Search Results:</h1>
+<h1>Your Search Keyword:</h1>
 <h2>{{searchword}}</h2>
 
 {{#unless restaurantList.length}}

--- a/views/cust/searchRestaurant.handlebars
+++ b/views/cust/searchRestaurant.handlebars
@@ -1,4 +1,4 @@
-<h1>Restaurant Found</h1>
+<h1>Search Results:</h1>
 <h2>{{searchword}}</h2>
 
 {{#unless restaurantList.length}}


### PR DESCRIPTION
Add `h1` tag to pages for accessibility compliance.
Rename `h1` tag in restaurant search result page.
Make reservation code more noticeable.